### PR TITLE
Unquote values (compat with mysql_config_editor 8.0.24)

### DIFF
--- a/login_test.go
+++ b/login_test.go
@@ -1,0 +1,27 @@
+package mylogin
+
+import "testing"
+
+func TestParseLine(t *testing.T) {
+	for _, test := range []struct {
+		line string
+		user string
+	}{
+		{`user = toto`, `toto`},
+		{`user = toto titi`, `toto titi`},
+		{`user = "toto"`, `toto`},
+		{`user = "toto titi"`, `toto titi`},
+		{`user = "toto = titi"`, `toto = titi`},
+		{`user = "toto \" titi"`, `toto " titi`},
+	} {
+		var l Login
+		err := l.parseLine(test.line)
+		if err != nil {
+			t.Errorf("%q: %v", test.line, err)
+			continue
+		}
+		if *l.User != test.user {
+			t.Errorf("%q: got %q, expected %q", test.line, *l.User, test.user)
+		}
+	}
+}

--- a/mylogin.go
+++ b/mylogin.go
@@ -108,6 +108,7 @@ func ReadSections(filename string) (sections Sections, err error) {
 // Parse parses the plaintext content of a mylogin.cnf file
 // and returns the structured content.
 func Parse(rd io.Reader) (sections Sections, err error) {
+	// Reference code: https://github.com/mysql/mysql-shell/blob/master/mysql-secret-store/login-path/login_path_helper.cc#L52
 	var login *Login
 	scanner := bufio.NewScanner(rd)
 	for scanner.Scan() {


### PR DESCRIPTION
Fix compatibility with mylogin.cnf encoded by mysql_config_editor
8.0.24: unquote values on read.

Reference commits in MySQL sources:
- https://github.com/mysql/mysql-server/commit/7d8028ac99730d4ccbe42d6edc11cc4f6d0cddca#diff-f8995fe51ada555169245803572ae5bd33a1793f6c027a39f8475c9156068ee5L518
- https://github.com/mysql/mysql-shell/commit/603b49ef73a6b7875a3f5d1ce4bc8a458d2707ae

This is an alternative implementation to #2.